### PR TITLE
更新了https下的api代理

### DIFF
--- a/open-api/main.yaml
+++ b/open-api/main.yaml
@@ -15,7 +15,7 @@ servers:
     description: Official Server
   - url: https://zyp.metasxz.org/api
     description: Proxy on Fastly
-  - url: http://115.29.169.60:8000/api
+  - url: https://zyapi.loshop.com.cn/api
     description: Proxy by Loshop
 
 paths:


### PR DESCRIPTION
将Loshop的api代理更改为了https协议